### PR TITLE
chore(release): v4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diffler",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diffler",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diffler",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A recursive JSON comparison script for humans",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps version to `4.0.1` (patch).

Merging will tag and publish to npm automatically.